### PR TITLE
MA-125: Implement save status and action history for create action

### DIFF
--- a/App.axaml
+++ b/App.axaml
@@ -31,6 +31,7 @@
 			<customConverters:ByteOpacityConverter x:Key="ByteOpacityConverter"/>
 			<customConverters:UseThemeConverter x:Key="UseThemeConverter"/>
 			<customConverters:DocumentStringConverter x:Key="DocumentStringConverter"/>
+			<customConverters:SaveStatusConverter x:Key="SaveStatusConverter"/>
 			<ResourceDictionary.MergedDictionaries>
 				<ResourceInclude Source="/Styles/ToolBarResources.axaml"/>
 				<ResourceInclude Source="/Styles/WorkspaceResources.axaml"/>

--- a/Constants/WorkspaceConstants.cs
+++ b/Constants/WorkspaceConstants.cs
@@ -18,6 +18,12 @@ public static class WorkspaceConstants
         SAVED
     }
 
+    public enum HISTORY_ACTION
+    {
+        UNDO,
+        REDO
+    }
+
     public static readonly Dictionary<SAVE_STATUS, string> save_status_text = new Dictionary<SAVE_STATUS, string>
     {
         { SAVE_STATUS.UNSAVED, "Unsaved" },

--- a/Constants/WorkspaceConstants.cs
+++ b/Constants/WorkspaceConstants.cs
@@ -1,4 +1,6 @@
-﻿namespace dboard.Constants;
+﻿using System.Collections.Generic;
+
+namespace dboard.Constants;
 
 public static class WorkspaceConstants
 {
@@ -8,4 +10,18 @@ public static class WorkspaceConstants
 
     public const double MIN_ZOOM = 0.2;
     public const double MAX_ZOOM = 3.0;
+
+    public enum SAVE_STATUS
+    {
+        UNSAVED,
+        SAVING,
+        SAVED
+    }
+
+    public static readonly Dictionary<SAVE_STATUS, string> save_status_text = new Dictionary<SAVE_STATUS, string>
+    {
+        { SAVE_STATUS.UNSAVED, "Unsaved" },
+        { SAVE_STATUS.SAVING, "Saving" },
+        { SAVE_STATUS.SAVED, "Saved" },
+    };
 }

--- a/Converters/SaveStatusConverter.cs
+++ b/Converters/SaveStatusConverter.cs
@@ -2,7 +2,6 @@
 using System.Globalization;
 using Avalonia.Data.Converters;
 using System.Collections.Generic;
-using Avalonia.Media;
 using dboard.Constants;
 
 namespace dboard.Converters;
@@ -12,11 +11,12 @@ public class SaveStatusConverter : IMultiValueConverter
 
     public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (values.Count == 2 && values[0] is string workspace_name && values[1] is WorkspaceConstants.SAVE_STATUS save_status)
+        if (values[1] is WorkspaceConstants.SAVE_STATUS save_status)
         {
-            return new Color(a, r, g, b);
+            string workspace_name = values[0] is null | values[0] is not string ? "New Workspace" : (string)values[0];
+            return workspace_name + " - " + WorkspaceConstants.save_status_text[save_status];
         }
-        return null;
+        return "";
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/Converters/SaveStatusConverter.cs
+++ b/Converters/SaveStatusConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using System.Collections.Generic;
+using Avalonia.Media;
+using dboard.Constants;
+
+namespace dboard.Converters;
+public class SaveStatusConverter : IMultiValueConverter
+{
+    public static readonly SaveStatusConverter Instance = new();
+
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Count == 2 && values[0] is string workspace_name && values[1] is WorkspaceConstants.SAVE_STATUS save_status)
+        {
+            return new Color(a, r, g, b);
+        }
+        return null;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return null;
+    }
+
+}

--- a/Messages/HistoryActionMessage.cs
+++ b/Messages/HistoryActionMessage.cs
@@ -1,0 +1,8 @@
+﻿using CommunityToolkit.Mvvm.Messaging.Messages;
+using dboard.Constants;
+
+namespace dboard.Messages;
+public class HistoryActionMessage : ValueChangedMessage<WorkspaceConstants.HISTORY_ACTION>
+{
+    public HistoryActionMessage(WorkspaceConstants.HISTORY_ACTION value) : base(value) { }
+}

--- a/Messages/LogActionMessage.cs
+++ b/Messages/LogActionMessage.cs
@@ -1,0 +1,8 @@
+﻿using CommunityToolkit.Mvvm.Messaging.Messages;
+using dboard.Models;
+
+namespace dboard.Messages;
+public class LogActionMessage : ValueChangedMessage<NodeActionModelBase>
+{
+    public LogActionMessage(NodeActionModelBase value) : base(value) { }
+}

--- a/Messages/ResetActionHistoryStatesMessage.cs
+++ b/Messages/ResetActionHistoryStatesMessage.cs
@@ -1,0 +1,8 @@
+﻿using CommunityToolkit.Mvvm.Messaging.Messages;
+using dboard.Models;
+
+namespace dboard.Messages;
+public class ResetActionHistoryStatesMessage : ValueChangedMessage<ResetActionHistoryStatesModel>
+{
+    public ResetActionHistoryStatesMessage(ResetActionHistoryStatesModel value) : base(value) { }
+}

--- a/Models/Actions/CreateNodeActionModel.cs
+++ b/Models/Actions/CreateNodeActionModel.cs
@@ -6,14 +6,14 @@ namespace dboard.Models;
 public partial class CreateNodeActionModel : NodeActionModelBase
 {
     public CreateNodeActionModel(
-        NodeViewModelBase nodeBefore, 
         NodeViewModelBase node
-    ) : base(nodeBefore, node) { }
+    ) : base(node) { }
 
     public override void Undo(WorkspaceViewModel workspaceVM)
     {
         if (Node is not null)
         {
+            NodeBeforeHistoryAction = Node.Clone();
             workspaceVM.Nodes.Remove(Node);
             Node = null;
         }
@@ -21,12 +21,15 @@ public partial class CreateNodeActionModel : NodeActionModelBase
 
     public override void Redo(WorkspaceViewModel workspaceVM)
     {
-        NodeViewModelBase NewNode = NodeAfterAction.Clone();
         if (Node is not null)
         {
             workspaceVM.Nodes.Remove(Node);
         }
-        workspaceVM.Nodes.Add(NewNode);
-        Node = NewNode;
+        if (NodeBeforeHistoryAction is not null)
+        {
+            workspaceVM.Nodes.Add(NodeBeforeHistoryAction);
+            Node = NodeBeforeHistoryAction;
+            NodeBeforeHistoryAction = null;
+        }
     }
 }

--- a/Models/Actions/CreateNodeActionModel.cs
+++ b/Models/Actions/CreateNodeActionModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.ObjectModel;
-using dboard.ViewModels;
+﻿using dboard.ViewModels;
 
 namespace dboard.Models;
 
@@ -7,28 +6,27 @@ namespace dboard.Models;
 public partial class CreateNodeActionModel : NodeActionModelBase
 {
     public CreateNodeActionModel(
-        ObservableCollection<NodeViewModelBase> nodes,
         NodeViewModelBase nodeBefore, 
         NodeViewModelBase node
-    ) : base(nodes, nodeBefore, node) { }
+    ) : base(nodeBefore, node) { }
 
-    public override void Undo()
+    public override void Undo(WorkspaceViewModel workspaceVM)
     {
         if (Node is not null)
         {
-            Nodes.Remove(Node);
+            workspaceVM.Nodes.Remove(Node);
             Node = null;
         }
     }
 
-    public override void Redo()
+    public override void Redo(WorkspaceViewModel workspaceVM)
     {
         NodeViewModelBase NewNode = NodeAfterAction.Clone();
         if (Node is not null)
         {
-            Nodes.Remove(Node);
+            workspaceVM.Nodes.Remove(Node);
         }
-        Nodes.Add(NewNode);
+        workspaceVM.Nodes.Add(NewNode);
         Node = NewNode;
     }
 }

--- a/Models/Actions/CreateNodeActionModel.cs
+++ b/Models/Actions/CreateNodeActionModel.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.ObjectModel;
+using dboard.ViewModels;
+
+namespace dboard.Models;
+
+
+public partial class CreateNodeActionModel : NodeActionModelBase
+{
+    public CreateNodeActionModel(
+        ObservableCollection<NodeViewModelBase> nodes,
+        NodeViewModelBase nodeBefore, 
+        NodeViewModelBase node
+    ) : base(nodes, nodeBefore, node) { }
+
+    public override void Undo()
+    {
+        if (Node is not null)
+        {
+            Nodes.Remove(Node);
+            Node = null;
+        }
+    }
+
+    public override void Redo()
+    {
+        NodeViewModelBase NewNode = NodeAfterAction.Clone();
+        if (Node is not null)
+        {
+            Nodes.Remove(Node);
+        }
+        Nodes.Add(NewNode);
+        Node = NewNode;
+    }
+}

--- a/Models/Actions/NodeActionModelBase.cs
+++ b/Models/Actions/NodeActionModelBase.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.ObjectModel;
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using dboard.ViewModels;
 
 namespace dboard.Models;
@@ -8,17 +7,13 @@ namespace dboard.Models;
 public abstract partial class NodeActionModelBase : ObservableObject
 {
     [ObservableProperty]
-    private NodeViewModelBase _nodeAfterAction;
-    [ObservableProperty]
-    private NodeViewModelBase _nodeBeforeAction;
+    private NodeViewModelBase? _nodeBeforeHistoryAction;
     [ObservableProperty]
     private NodeViewModelBase? _node;
 
-    public NodeActionModelBase(NodeViewModelBase nodeBefore, NodeViewModelBase node)
+    public NodeActionModelBase(NodeViewModelBase node)
     {
-        NodeBeforeAction = nodeBefore;
         Node = node;
-        NodeAfterAction = node.Clone();
     }
 
     abstract public void Undo(WorkspaceViewModel workspaceVM);

--- a/Models/Actions/NodeActionModelBase.cs
+++ b/Models/Actions/NodeActionModelBase.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using dboard.ViewModels;
+
+namespace dboard.Models;
+
+
+public abstract partial class NodeActionModelBase : ObservableObject
+{
+    public ObservableCollection<NodeViewModelBase> Nodes;
+    [ObservableProperty]
+    private NodeViewModelBase _nodeAfterAction;
+    [ObservableProperty]
+    private NodeViewModelBase _nodeBeforeAction;
+    [ObservableProperty]
+    private NodeViewModelBase? _node;
+
+    public NodeActionModelBase(ObservableCollection<NodeViewModelBase> nodes, NodeViewModelBase nodeBefore, NodeViewModelBase node)
+    {
+        Nodes = nodes;
+        NodeBeforeAction = nodeBefore;
+        Node = node;
+        NodeAfterAction = node.Clone();
+    }
+
+    abstract public void Undo();
+
+    abstract public void Redo();
+}

--- a/Models/Actions/NodeActionModelBase.cs
+++ b/Models/Actions/NodeActionModelBase.cs
@@ -7,7 +7,6 @@ namespace dboard.Models;
 
 public abstract partial class NodeActionModelBase : ObservableObject
 {
-    public ObservableCollection<NodeViewModelBase> Nodes;
     [ObservableProperty]
     private NodeViewModelBase _nodeAfterAction;
     [ObservableProperty]
@@ -15,15 +14,14 @@ public abstract partial class NodeActionModelBase : ObservableObject
     [ObservableProperty]
     private NodeViewModelBase? _node;
 
-    public NodeActionModelBase(ObservableCollection<NodeViewModelBase> nodes, NodeViewModelBase nodeBefore, NodeViewModelBase node)
+    public NodeActionModelBase(NodeViewModelBase nodeBefore, NodeViewModelBase node)
     {
-        Nodes = nodes;
         NodeBeforeAction = nodeBefore;
         Node = node;
         NodeAfterAction = node.Clone();
     }
 
-    abstract public void Undo();
+    abstract public void Undo(WorkspaceViewModel workspaceVM);
 
-    abstract public void Redo();
+    abstract public void Redo(WorkspaceViewModel workspaceVM);
 }

--- a/Models/Actions/ResetActionHistoryStatesModel.cs
+++ b/Models/Actions/ResetActionHistoryStatesModel.cs
@@ -9,10 +9,13 @@ public partial class ResetActionHistoryStatesModel : ObservableObject
     private bool _isSave;
     [ObservableProperty]
     private bool _resetActionHistory;
+    [ObservableProperty]
+    private bool _shouldAlwaysBeUnsaved;
 
-    public ResetActionHistoryStatesModel(bool isSave, bool resetActionHistory)
+    public ResetActionHistoryStatesModel(bool isSave, bool resetActionHistory, bool shouldAlwaysBeUnsaved)
     {
         IsSave = isSave;
         ResetActionHistory = resetActionHistory;
+        ShouldAlwaysBeUnsaved = shouldAlwaysBeUnsaved;
     }
 }

--- a/Models/Actions/ResetActionHistoryStatesModel.cs
+++ b/Models/Actions/ResetActionHistoryStatesModel.cs
@@ -1,0 +1,18 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace dboard.Models;
+
+
+public partial class ResetActionHistoryStatesModel : ObservableObject
+{
+    [ObservableProperty]
+    private bool _isSave;
+    [ObservableProperty]
+    private bool _resetActionHistory;
+
+    public ResetActionHistoryStatesModel(bool isSave, bool resetActionHistory)
+    {
+        IsSave = isSave;
+        ResetActionHistory = resetActionHistory;
+    }
+}

--- a/Models/NodeModel.cs
+++ b/Models/NodeModel.cs
@@ -64,4 +64,19 @@ public partial class NodeModel : NodeModelBase
 
     [ObservableProperty]
     private bool _notesToggled;
+
+    public override NodeModel Clone()
+    {
+        return new NodeModel(
+            Name,
+            Desc,
+            ImagePath,
+            Width,
+            Height,
+            PositionX,
+            PositionY,
+            Notes,
+            ZIndex
+        );
+    }
 }

--- a/Models/NodeModelBase.cs
+++ b/Models/NodeModelBase.cs
@@ -23,4 +23,6 @@ public abstract partial class NodeModelBase : ObservableObject
 
     [ObservableProperty]
     private int _zIndex;
+
+    abstract public NodeModelBase Clone();
 }

--- a/ViewModels/MainContentViewModel.cs
+++ b/ViewModels/MainContentViewModel.cs
@@ -51,7 +51,7 @@ public partial class MainContentViewModel : ObservableObject
         Workspace = new WorkspaceViewModel(SharedSettings);
         Notes = new NotesModel();
         WorkspaceFileName = null;
-        WeakReferenceMessenger.Default.Send(new ResetActionHistoryStatesMessage(new ResetActionHistoryStatesModel(false, true)));
+        WeakReferenceMessenger.Default.Send(new ResetActionHistoryStatesMessage(new ResetActionHistoryStatesModel(false, true, true)));
     }
 
     public void LoadWorkspace(WorkspaceModel newWorkspace, string workspaceName)

--- a/ViewModels/MainContentViewModel.cs
+++ b/ViewModels/MainContentViewModel.cs
@@ -51,6 +51,7 @@ public partial class MainContentViewModel : ObservableObject
         Workspace = new WorkspaceViewModel(SharedSettings);
         Notes = new NotesModel();
         WorkspaceFileName = null;
+        WeakReferenceMessenger.Default.Send(new ResetActionHistoryStatesMessage(new ResetActionHistoryStatesModel(false, true)));
     }
 
     public void LoadWorkspace(WorkspaceModel newWorkspace, string workspaceName)

--- a/ViewModels/MainContentViewModel.cs
+++ b/ViewModels/MainContentViewModel.cs
@@ -20,6 +20,8 @@ public partial class MainContentViewModel : ObservableObject
     private SettingsModel _sharedSettings;
     [ObservableProperty]
     private string? _workspaceFileName;
+    [ObservableProperty]
+    private WorkspaceConstants.SAVE_STATUS _saveStatus;
 
     public MainContentViewModel(SettingsModel sharedSettings)
     {
@@ -28,6 +30,7 @@ public partial class MainContentViewModel : ObservableObject
         Settings = new AppSettingsViewModel(sharedSettings);
         Notes = new NotesModel();
         WorkspaceFileName = null;
+        SaveStatus = WorkspaceConstants.SAVE_STATUS.UNSAVED;
     }
 
     [RelayCommand]
@@ -50,7 +53,7 @@ public partial class MainContentViewModel : ObservableObject
         WorkspaceFileName = null;
     }
 
-    public void NewWorkspace(WorkspaceModel newWorkspace, string workspaceName)
+    public void LoadWorkspace(WorkspaceModel newWorkspace, string workspaceName)
     {
         New();
         foreach (var node in newWorkspace.Nodes)

--- a/ViewModels/MainContentViewModel.cs
+++ b/ViewModels/MainContentViewModel.cs
@@ -83,4 +83,13 @@ public partial class MainContentViewModel : ObservableObject
                 Workspace.WindowImagePath
             };
     }
+
+    public bool Equals(MainContentViewModel viewModel)
+    {
+        if (Workspace.Equals(viewModel.Workspace))
+        {
+            return true;
+        }
+        return false;
+    }
 }

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -100,4 +100,16 @@ public partial class MainWindowViewModel : ObservableObject
             }
         }
     }
+
+    [RelayCommand]
+    private void Undo()
+    {
+        WeakReferenceMessenger.Default.Send(new HistoryActionMessage(WorkspaceConstants.HISTORY_ACTION.UNDO));
+    }
+
+    [RelayCommand]
+    private void Redo()
+    {
+        WeakReferenceMessenger.Default.Send(new HistoryActionMessage(WorkspaceConstants.HISTORY_ACTION.REDO));
+    }
 }

--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -138,7 +138,7 @@ public partial class WorkspaceViewModel : ObservableObject
         nodeModel.PositionY = y;
         NodeViewModel nodeVM = new NodeViewModel(nodeModel);
         Nodes.Add(nodeVM);
-        WeakReferenceMessenger.Default.Send(new LogActionMessage(new CreateNodeActionModel(nodeVM.Clone(), nodeVM)));
+        WeakReferenceMessenger.Default.Send(new LogActionMessage(new CreateNodeActionModel(nodeVM)));
     }
 
     [RelayCommand]
@@ -201,7 +201,7 @@ public partial class WorkspaceViewModel : ObservableObject
     {
         NodeViewModel nodeVM = new NodeViewModel(new NodeModel(Nodes.Count));
         Nodes.Add(nodeVM);
-        WeakReferenceMessenger.Default.Send(new CreateNodeActionModel(nodeVM.Clone(), nodeVM));
+        WeakReferenceMessenger.Default.Send(new CreateNodeActionModel(nodeVM));
     }
 
     private void _DeleteNodes()

--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -138,7 +138,7 @@ public partial class WorkspaceViewModel : ObservableObject
         nodeModel.PositionY = y;
         NodeViewModel nodeVM = new NodeViewModel(nodeModel);
         Nodes.Add(nodeVM);
-        WeakReferenceMessenger.Default.Send(new CreateNodeActionModel(Nodes, nodeVM.Clone(), nodeVM));
+        WeakReferenceMessenger.Default.Send(new LogActionMessage(new CreateNodeActionModel(Nodes, nodeVM.Clone(), nodeVM)));
     }
 
     [RelayCommand]
@@ -200,7 +200,7 @@ public partial class WorkspaceViewModel : ObservableObject
     private void _CreateEmptyNode()
     {
         NodeViewModel nodeVM = new NodeViewModel(new NodeModel(Nodes.Count));
-        Nodes.Add(new NodeViewModel(nodeVM);
+        Nodes.Add(nodeVM);
         WeakReferenceMessenger.Default.Send(new CreateNodeActionModel(Nodes, nodeVM.Clone(), nodeVM));
     }
 

--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -136,7 +136,9 @@ public partial class WorkspaceViewModel : ObservableObject
         NodeModel nodeModel = new NodeModel(Nodes.Count);
         nodeModel.PositionX = x;
         nodeModel.PositionY = y;
-        Nodes.Add(new NodeViewModel(nodeModel));
+        NodeViewModel nodeVM = new NodeViewModel(nodeModel);
+        Nodes.Add(nodeVM);
+        WeakReferenceMessenger.Default.Send(new CreateNodeActionModel(Nodes, nodeVM.Clone(), nodeVM));
     }
 
     [RelayCommand]
@@ -197,7 +199,9 @@ public partial class WorkspaceViewModel : ObservableObject
 
     private void _CreateEmptyNode()
     {
-        Nodes.Add(new NodeViewModel(new NodeModel(Nodes.Count)));
+        NodeViewModel nodeVM = new NodeViewModel(new NodeModel(Nodes.Count));
+        Nodes.Add(new NodeViewModel(nodeVM);
+        WeakReferenceMessenger.Default.Send(new CreateNodeActionModel(Nodes, nodeVM.Clone(), nodeVM));
     }
 
     private void _DeleteNodes()

--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -138,7 +138,7 @@ public partial class WorkspaceViewModel : ObservableObject
         nodeModel.PositionY = y;
         NodeViewModel nodeVM = new NodeViewModel(nodeModel);
         Nodes.Add(nodeVM);
-        WeakReferenceMessenger.Default.Send(new LogActionMessage(new CreateNodeActionModel(Nodes, nodeVM.Clone(), nodeVM)));
+        WeakReferenceMessenger.Default.Send(new LogActionMessage(new CreateNodeActionModel(nodeVM.Clone(), nodeVM)));
     }
 
     [RelayCommand]
@@ -201,7 +201,7 @@ public partial class WorkspaceViewModel : ObservableObject
     {
         NodeViewModel nodeVM = new NodeViewModel(new NodeModel(Nodes.Count));
         Nodes.Add(nodeVM);
-        WeakReferenceMessenger.Default.Send(new CreateNodeActionModel(Nodes, nodeVM.Clone(), nodeVM));
+        WeakReferenceMessenger.Default.Send(new CreateNodeActionModel(nodeVM.Clone(), nodeVM));
     }
 
     private void _DeleteNodes()

--- a/Views/MainContentView.axaml
+++ b/Views/MainContentView.axaml
@@ -45,6 +45,7 @@
 				<MenuItem Header="Paste" Command="{Binding Workspace.PasteNodesCommand}"/>
 				<MenuItem Header="Delete" Command="{Binding Workspace.DeleteSelectedItemsCommand}"/>
 			</MenuItem>
+			<MenuItem x:Name="WorkspaceStatus" Header="WORKSPACE_NAME* - Saving"/>
 		</Menu>
 
 		<!-- Right side -->

--- a/Views/MainContentView.axaml
+++ b/Views/MainContentView.axaml
@@ -45,7 +45,14 @@
 				<MenuItem Header="Paste" Command="{Binding Workspace.PasteNodesCommand}"/>
 				<MenuItem Header="Delete" Command="{Binding Workspace.DeleteSelectedItemsCommand}"/>
 			</MenuItem>
-			<MenuItem x:Name="WorkspaceStatus" Header="WORKSPACE_NAME* - Saving"/>
+			<MenuItem x:Name="WorkspaceStatus">
+				<MenuItem.Header>
+					<MultiBinding Converter="{StaticResource SaveStatusConverter}">
+						<Binding Path="WorkspaceFileName"/>
+						<Binding Path="SaveStatus"/>
+					</MultiBinding>
+				</MenuItem.Header>
+			</MenuItem>
 		</Menu>
 
 		<!-- Right side -->

--- a/Views/MainContentView.axaml.cs
+++ b/Views/MainContentView.axaml.cs
@@ -65,9 +65,11 @@ public partial class MainContentView : Grid
 
     public void Undo()
     {
-        if (_lastActionIndex >= 0)
+        MainContentViewModel vm = (MainContentViewModel)DataContext;
+        
+        if (_lastActionIndex >= 0 && vm is not null)
         {
-            _actionHistory[_lastActionIndex].Undo();
+            _actionHistory[_lastActionIndex].Undo(vm.Workspace);
             _lastActionIndex -= 1;
             UpdateSaveStatus();
         }
@@ -75,10 +77,11 @@ public partial class MainContentView : Grid
 
     public void Redo()
     {
-        if (_lastActionIndex < _actionHistory.Count - 1)
+        MainContentViewModel vm = (MainContentViewModel)DataContext;
+        if (_lastActionIndex < _actionHistory.Count - 1 && vm is not null)
         {
             _lastActionIndex += 1;
-            _actionHistory[_lastActionIndex].Redo();
+            _actionHistory[_lastActionIndex].Redo(vm.Workspace);
             UpdateSaveStatus();
         }
     }

--- a/Views/MainContentView.axaml.cs
+++ b/Views/MainContentView.axaml.cs
@@ -69,18 +69,18 @@ public partial class MainContentView : Grid
         {
             _actionHistory[_lastActionIndex].Undo();
             _lastActionIndex -= 1;
+            UpdateSaveStatus();
         }
-        UpdateSaveStatus();
     }
 
     public void Redo()
     {
         if (_lastActionIndex < _actionHistory.Count - 1)
         {
-            _actionHistory[_lastActionIndex].Redo();
             _lastActionIndex += 1;
+            _actionHistory[_lastActionIndex].Redo();
+            UpdateSaveStatus();
         }
-        UpdateSaveStatus();
     }
 
     public void LogAction(NodeActionModelBase action)
@@ -187,6 +187,19 @@ public partial class MainContentView : Grid
         {
             ResetActionHistoryStatesModel val = message.Value;
             ResetActionHistoryStates(val.IsSave, val.ResetActionHistory, val.ShouldAlwaysBeUnsaved);
+        });
+
+        WeakReferenceMessenger.Default.Register<HistoryActionMessage>(this, (sender, message) =>
+        {
+            WorkspaceConstants.HISTORY_ACTION historyAction = message.Value;
+            if (historyAction == WorkspaceConstants.HISTORY_ACTION.UNDO)
+            {
+                Undo();
+            }
+            else if (historyAction == WorkspaceConstants.HISTORY_ACTION.REDO)
+            {
+                Redo();
+            }
         });
     }
 

--- a/Views/MainContentView.axaml.cs
+++ b/Views/MainContentView.axaml.cs
@@ -31,6 +31,7 @@ public partial class MainContentView : Grid
     private double _lastNotesLen;
     private SplitView _notesSplitView;
     private Control _workspaceCanvas;
+    private MainContentViewModel _previousVM;
 
     JsonSerializerOptions options = new()
     {
@@ -84,6 +85,8 @@ public partial class MainContentView : Grid
 
         notesBorder.BindClass("LightAccent", LightAccentMB, null);
         notesBorder.BindClass("DarkAccent", DarkAccentMB, null);
+
+        _previousVM = (MainContentViewModel)DataContext;
     }
 
     protected async void SaveEvent(object sender, RoutedEventArgs e)
@@ -143,14 +146,14 @@ public partial class MainContentView : Grid
 
     private async void _SaveFile(IStorageFile file)
     {
-        vm.SaveStatus = Constants.WorkspaceConstants.SAVE_STATUS.SAVING;
+        MainContentViewModel vm = (MainContentViewModel)DataContext;
+        vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.SAVING;
         // Open writing stream from the file.
         await using var stream = await file.OpenWriteAsync();
 
         WorkspaceViewModel workspaceVM = ((MainContentViewModel)DataContext).Workspace;
         List<NodeModelBase> nodes = workspaceVM.Nodes.Select(x => x.NodeBase).ToList();
         List<EdgeModel> edges = workspaceVM.Edges.Select(x => x.Edge).ToList();
-        MainContentViewModel vm = (MainContentViewModel)DataContext;
         NotesModel notes = vm.Notes;
         WorkspaceModel workspace = new WorkspaceModel(
             nodes, 
@@ -166,6 +169,7 @@ public partial class MainContentView : Grid
         await JsonSerializer.SerializeAsync(stream, workspace, options);
         ((MainContentViewModel)DataContext).WorkspaceFileName = file.Name;
         vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.SAVED;
+        _previousVM = vm;
     }
 
     protected async void Open(object sender, RoutedEventArgs e)
@@ -192,6 +196,7 @@ public partial class MainContentView : Grid
             WorkspaceModel workspace = JsonSerializer.Deserialize<WorkspaceModel>(stream, options);
             vm.LoadWorkspace(workspace, files[0].Name);
             vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.SAVED;
+            _previousVM = vm;
         }
     }
 

--- a/Views/MainContentView.axaml.cs
+++ b/Views/MainContentView.axaml.cs
@@ -31,7 +31,46 @@ public partial class MainContentView : Grid
     private double _lastNotesLen;
     private SplitView _notesSplitView;
     private Control _workspaceCanvas;
-    private MainContentViewModel _previousVM;
+    private List<NodeActionModelBase> _actionHistory = new List<NodeActionModelBase>();
+    private int _maxActions = 30;
+    private int _lastActionIndex = -1;
+
+    public void Undo()
+    {
+        if (_lastActionIndex >= 0)
+        {
+            _actionHistory[_lastActionIndex].Undo();
+            _lastActionIndex -= 1;
+        }
+    }
+
+    public void Redo()
+    {
+        if (_lastActionIndex < _actionHistory.Count - 1)
+        {
+            _actionHistory[_lastActionIndex].Redo();
+            _lastActionIndex += 1;
+        }
+    }
+
+    public void LogAction(NodeActionModelBase action)
+    {
+        // Remove undone actions
+        int actionCount = _actionHistory.Count;
+        for (int i = actionCount - 1; i > _lastActionIndex; i--)
+        {
+            _actionHistory.RemoveAt(i);
+        }
+
+        // Pop least recent action if there are too many
+        actionCount = _actionHistory.Count;
+        for (int i = actionCount; i > _maxActions; i--)
+        {
+            _actionHistory.RemoveAt(0);
+        }
+
+        _actionHistory.Add(action);
+    }
 
     JsonSerializerOptions options = new()
     {
@@ -85,8 +124,6 @@ public partial class MainContentView : Grid
 
         notesBorder.BindClass("LightAccent", LightAccentMB, null);
         notesBorder.BindClass("DarkAccent", DarkAccentMB, null);
-
-        _previousVM = (MainContentViewModel)DataContext;
     }
 
     protected async void SaveEvent(object sender, RoutedEventArgs e)
@@ -169,7 +206,6 @@ public partial class MainContentView : Grid
         await JsonSerializer.SerializeAsync(stream, workspace, options);
         ((MainContentViewModel)DataContext).WorkspaceFileName = file.Name;
         vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.SAVED;
-        _previousVM = vm;
     }
 
     protected async void Open(object sender, RoutedEventArgs e)
@@ -196,7 +232,6 @@ public partial class MainContentView : Grid
             WorkspaceModel workspace = JsonSerializer.Deserialize<WorkspaceModel>(stream, options);
             vm.LoadWorkspace(workspace, files[0].Name);
             vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.SAVED;
-            _previousVM = vm;
         }
     }
 

--- a/Views/MainContentView.axaml.cs
+++ b/Views/MainContentView.axaml.cs
@@ -143,13 +143,15 @@ public partial class MainContentView : Grid
 
     private async void _SaveFile(IStorageFile file)
     {
+        vm.SaveStatus = Constants.WorkspaceConstants.SAVE_STATUS.SAVING;
         // Open writing stream from the file.
         await using var stream = await file.OpenWriteAsync();
 
         WorkspaceViewModel workspaceVM = ((MainContentViewModel)DataContext).Workspace;
         List<NodeModelBase> nodes = workspaceVM.Nodes.Select(x => x.NodeBase).ToList();
         List<EdgeModel> edges = workspaceVM.Edges.Select(x => x.Edge).ToList();
-        NotesModel notes = ((MainContentViewModel)DataContext).Notes;
+        MainContentViewModel vm = (MainContentViewModel)DataContext;
+        NotesModel notes = vm.Notes;
         WorkspaceModel workspace = new WorkspaceModel(
             nodes, 
             edges, 
@@ -163,6 +165,7 @@ public partial class MainContentView : Grid
             workspaceVM.WindowImagePath);
         await JsonSerializer.SerializeAsync(stream, workspace, options);
         ((MainContentViewModel)DataContext).WorkspaceFileName = file.Name;
+        vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.SAVED;
     }
 
     protected async void Open(object sender, RoutedEventArgs e)
@@ -187,7 +190,8 @@ public partial class MainContentView : Grid
             MainContentViewModel vm = (MainContentViewModel)DataContext;
             await using var stream = await files[0].OpenReadAsync();
             WorkspaceModel workspace = JsonSerializer.Deserialize<WorkspaceModel>(stream, options);
-            vm.NewWorkspace(workspace, files[0].Name);
+            vm.LoadWorkspace(workspace, files[0].Name);
+            vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.SAVED;
         }
     }
 

--- a/Views/MainContentView.axaml.cs
+++ b/Views/MainContentView.axaml.cs
@@ -36,16 +36,26 @@ public partial class MainContentView : Grid
     private List<NodeActionModelBase> _actionHistory = new List<NodeActionModelBase>();
     private int _maxActions = 30;
     private int _lastActionIndex = -1;
-    // TODO: Logic for tracking save status
-    // Have two variables, lastActionSinceSave and actionHistoryCanBeUsedToGoBackToLastSave (rename this lol), default to true
-    // If in new workspace / open a workspace, have variable lastActionSinceSave be null, actionHistoryCanBeUsedToGoBackToLastSave be true
-    // If actionHistory ever passes maxActions / need to delete history, set actionHistoryCanBeUsedToGoBackToLastSave to false
-    // If just saving a workspace, set lastActionSinceSave to last action (can be null if there is no history)
-    // If the last action since save (if not null) gets popped, set actionHistoryCanBeUsedToGoBackToLastSave to false
+    // Action history states
+    private NodeActionModelBase? _lastActionSinceSave = null;
+    private bool _lastActionGone = false;
 
-    // To determine status (Saved or Unsaved)
-    // If lastAction is not null, check if action at lastActionIndex is same as lastAction, if so then saved, otherwise no. Also use actionHistoryCanBeUsedToGoBackToLastSave
-    // If lastAction is null, check if lastActionIndex is -1 and also actionHistoryCanBeUsedToGoBackToLastSave (since -1 doesn't always mean back to the start, since actionHistory has max
+    // History logging starts here
+    public void UpdateSaveStatus()
+    {
+        MainContentViewModel vm = (MainContentViewModel)DataContext;
+        if (vm is not null)
+        {
+            if (_actionHistory[_lastActionIndex] == _lastActionSinceSave)
+            {
+                vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.SAVED;
+            }
+            else
+            {
+                vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.UNSAVED;
+            }
+        }
+    }
 
     public void Undo()
     {
@@ -54,6 +64,7 @@ public partial class MainContentView : Grid
             _actionHistory[_lastActionIndex].Undo();
             _lastActionIndex -= 1;
         }
+        UpdateSaveStatus();
     }
 
     public void Redo()
@@ -63,6 +74,7 @@ public partial class MainContentView : Grid
             _actionHistory[_lastActionIndex].Redo();
             _lastActionIndex += 1;
         }
+        UpdateSaveStatus();
     }
 
     public void LogAction(NodeActionModelBase action)
@@ -82,7 +94,24 @@ public partial class MainContentView : Grid
         }
 
         _actionHistory.Add(action);
+        UpdateSaveStatus();
     }
+
+    private void ResetActionHistoryStates(bool isSave, bool resetActionHistory)
+    {
+        _lastActionGone = false;
+        if (resetActionHistory)
+        {
+            _lastActionSinceSave = null;
+            _actionHistory.Clear();
+            _lastActionIndex = -1;
+        }
+        if (isSave)
+        {
+            _lastActionSinceSave = _actionHistory[_lastActionIndex];
+        }
+    }
+    // History logging ends here
 
     JsonSerializerOptions options = new()
     {
@@ -141,6 +170,12 @@ public partial class MainContentView : Grid
         WeakReferenceMessenger.Default.Register<LogActionMessage>(this, (sender, message) =>
         {
             LogAction(message.Value);
+        });
+        
+        WeakReferenceMessenger.Default.Register<ResetActionHistoryStatesMessage>(this, (sender, message) =>
+        {
+            ResetActionHistoryStatesModel val = message.Value;
+            ResetActionHistoryStates(val.IsSave, val.ResetActionHistory);
         });
     }
 
@@ -224,6 +259,7 @@ public partial class MainContentView : Grid
         await JsonSerializer.SerializeAsync(stream, workspace, options);
         ((MainContentViewModel)DataContext).WorkspaceFileName = file.Name;
         vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.SAVED;
+        ResetActionHistoryStates(true, false);
     }
 
     protected async void Open(object sender, RoutedEventArgs e)
@@ -251,6 +287,8 @@ public partial class MainContentView : Grid
             vm.LoadWorkspace(workspace, files[0].Name);
             vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.SAVED;
         }
+
+        ResetActionHistoryStates(false, true);
     }
 
     protected void Exit(object sender, RoutedEventArgs e)

--- a/Views/MainContentView.axaml.cs
+++ b/Views/MainContentView.axaml.cs
@@ -36,6 +36,16 @@ public partial class MainContentView : Grid
     private List<NodeActionModelBase> _actionHistory = new List<NodeActionModelBase>();
     private int _maxActions = 30;
     private int _lastActionIndex = -1;
+    // TODO: Logic for tracking save status
+    // Have two variables, lastActionSinceSave and actionHistoryCanBeUsedToGoBackToLastSave (rename this lol), default to true
+    // If in new workspace / open a workspace, have variable lastActionSinceSave be null, actionHistoryCanBeUsedToGoBackToLastSave be true
+    // If actionHistory ever passes maxActions / need to delete history, set actionHistoryCanBeUsedToGoBackToLastSave to false
+    // If just saving a workspace, set lastActionSinceSave to last action (can be null if there is no history)
+    // If the last action since save (if not null) gets popped, set actionHistoryCanBeUsedToGoBackToLastSave to false
+
+    // To determine status (Saved or Unsaved)
+    // If lastAction is not null, check if action at lastActionIndex is same as lastAction, if so then saved, otherwise no. Also use actionHistoryCanBeUsedToGoBackToLastSave
+    // If lastAction is null, check if lastActionIndex is -1 and also actionHistoryCanBeUsedToGoBackToLastSave (since -1 doesn't always mean back to the start, since actionHistory has max
 
     public void Undo()
     {

--- a/Views/MainContentView.axaml.cs
+++ b/Views/MainContentView.axaml.cs
@@ -16,7 +16,9 @@ using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
+using CommunityToolkit.Mvvm.Messaging;
 using dboard.Constants;
+using dboard.Messages;
 using dboard.Models;
 using dboard.Tools;
 using dboard.ViewModels;
@@ -124,6 +126,12 @@ public partial class MainContentView : Grid
 
         notesBorder.BindClass("LightAccent", LightAccentMB, null);
         notesBorder.BindClass("DarkAccent", DarkAccentMB, null);
+
+        // Set up for logging
+        WeakReferenceMessenger.Default.Register<LogActionMessage>(this, (sender, message) =>
+        {
+            LogAction(message.Value);
+        });
     }
 
     protected async void SaveEvent(object sender, RoutedEventArgs e)

--- a/Views/MainContentView.axaml.cs
+++ b/Views/MainContentView.axaml.cs
@@ -38,7 +38,7 @@ public partial class MainContentView : Grid
     private int _lastActionIndex = -1;
     // Action history states
     private NodeActionModelBase? _lastActionSinceSave = null;
-    private bool _lastActionGone = false;
+    private bool _shouldAlwaysBeUnsaved = true;
 
     // History logging starts here
     public void UpdateSaveStatus()
@@ -46,7 +46,13 @@ public partial class MainContentView : Grid
         MainContentViewModel vm = (MainContentViewModel)DataContext;
         if (vm is not null)
         {
-            if (_actionHistory[_lastActionIndex] == _lastActionSinceSave)
+            if (
+                !_shouldAlwaysBeUnsaved &&
+                (
+                (_lastActionSinceSave is null && _lastActionIndex == -1) ||
+                (_lastActionIndex != -1 && _actionHistory[_lastActionIndex] == _lastActionSinceSave)
+                )
+            )
             {
                 vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.SAVED;
             }
@@ -94,12 +100,13 @@ public partial class MainContentView : Grid
         }
 
         _actionHistory.Add(action);
+        _lastActionIndex = _actionHistory.Count - 1;
         UpdateSaveStatus();
     }
 
-    private void ResetActionHistoryStates(bool isSave, bool resetActionHistory)
+    private void ResetActionHistoryStates(bool isSave, bool resetActionHistory, bool shouldAlwaysBeUnsaved)
     {
-        _lastActionGone = false;
+        _shouldAlwaysBeUnsaved = shouldAlwaysBeUnsaved;
         if (resetActionHistory)
         {
             _lastActionSinceSave = null;
@@ -108,8 +115,12 @@ public partial class MainContentView : Grid
         }
         if (isSave)
         {
-            _lastActionSinceSave = _actionHistory[_lastActionIndex];
+            if (_lastActionIndex != -1)
+            {
+                _lastActionSinceSave = _actionHistory[_lastActionIndex];
+            }
         }
+        UpdateSaveStatus();
     }
     // History logging ends here
 
@@ -175,7 +186,7 @@ public partial class MainContentView : Grid
         WeakReferenceMessenger.Default.Register<ResetActionHistoryStatesMessage>(this, (sender, message) =>
         {
             ResetActionHistoryStatesModel val = message.Value;
-            ResetActionHistoryStates(val.IsSave, val.ResetActionHistory);
+            ResetActionHistoryStates(val.IsSave, val.ResetActionHistory, val.ShouldAlwaysBeUnsaved);
         });
     }
 
@@ -259,7 +270,7 @@ public partial class MainContentView : Grid
         await JsonSerializer.SerializeAsync(stream, workspace, options);
         ((MainContentViewModel)DataContext).WorkspaceFileName = file.Name;
         vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.SAVED;
-        ResetActionHistoryStates(true, false);
+        ResetActionHistoryStates(true, false, false);
     }
 
     protected async void Open(object sender, RoutedEventArgs e)
@@ -288,7 +299,7 @@ public partial class MainContentView : Grid
             vm.SaveStatus = WorkspaceConstants.SAVE_STATUS.SAVED;
         }
 
-        ResetActionHistoryStates(false, true);
+        ResetActionHistoryStates(false, true, false);
     }
 
     protected void Exit(object sender, RoutedEventArgs e)

--- a/Views/MainWindowView.axaml
+++ b/Views/MainWindowView.axaml
@@ -31,6 +31,8 @@
 	<Window.KeyBindings>
 		<KeyBinding Gesture="Tab" Command="{Binding ToggleModeCommand}" />
 		<KeyBinding Gesture="Ctrl+F" Command="{Binding ToggleFullScreenCommand}" />
+		<KeyBinding Gesture="Ctrl+Z" Command="{Binding UndoCommand}" />
+		<KeyBinding Gesture="Ctrl+Shift+Z" Command="{Binding RedoCommand}" />
 	</Window.KeyBindings>
 
 	<TransitioningContentControl Content="{Binding CurrentPage}" />


### PR DESCRIPTION
﻿ ### Summary
Implemented save statuses of board, in addition to tracking actions to update the status.
Infrastructure for tracking actions implemented, can undo and redo actions, but the only actions recorded are create currently
(SCOPE EXPANDED A LOT)
 ### Changes
- Have saved / unsaved / saving statuses
- Have action history tracking infrastructure set up
- Record create actions that can be undone and redone