### PR TITLE
MA-152: Added undo and redo for deleting nodes

### DIFF
--- a/Models/Actions/CreateNodeActionModel.cs
+++ b/Models/Actions/CreateNodeActionModel.cs
@@ -11,25 +11,14 @@ public partial class CreateNodeActionModel : NodeActionModelBase
 
     public override void Undo(WorkspaceViewModel workspaceVM)
     {
-        if (Node is not null)
-        {
-            NodeBeforeHistoryAction = Node.Clone();
-            workspaceVM.Nodes.Remove(Node);
-            Node = null;
-        }
+        workspaceVM.Nodes.Remove(Node);
     }
 
     public override void Redo(WorkspaceViewModel workspaceVM)
     {
-        if (Node is not null)
+        if (!workspaceVM.Nodes.Contains(Node))
         {
-            workspaceVM.Nodes.Remove(Node);
-        }
-        if (NodeBeforeHistoryAction is not null)
-        {
-            workspaceVM.Nodes.Add(NodeBeforeHistoryAction);
-            Node = NodeBeforeHistoryAction;
-            NodeBeforeHistoryAction = null;
+            workspaceVM.Nodes.Add(Node);
         }
     }
 }

--- a/Models/Actions/DeleteNodeActionModel.cs
+++ b/Models/Actions/DeleteNodeActionModel.cs
@@ -1,0 +1,30 @@
+﻿using dboard.ViewModels;
+
+namespace dboard.Models;
+
+
+public partial class DeleteNodeActionModel : NodeActionModelBase
+{
+    public DeleteNodeActionModel(
+        NodeViewModelBase node
+    ) : base(node) { NodeBeforeHistoryAction = node.Clone(); }
+
+    public override void Undo(WorkspaceViewModel workspaceVM)
+    {
+        if (NodeBeforeHistoryAction is not null)
+        {
+            workspaceVM.Nodes.Add(NodeBeforeHistoryAction);
+            Node = NodeBeforeHistoryAction;
+            NodeBeforeHistoryAction = null;
+        }
+    }
+
+    public override void Redo(WorkspaceViewModel workspaceVM)
+    {
+        if (Node is not null)
+        {
+            NodeBeforeHistoryAction = Node.Clone();
+            workspaceVM.Nodes.Remove(Node);
+        }
+    }
+}

--- a/Models/Actions/DeleteNodeActionModel.cs
+++ b/Models/Actions/DeleteNodeActionModel.cs
@@ -7,24 +7,18 @@ public partial class DeleteNodeActionModel : NodeActionModelBase
 {
     public DeleteNodeActionModel(
         NodeViewModelBase node
-    ) : base(node) { NodeBeforeHistoryAction = node.Clone(); }
+    ) : base(node) { }
 
     public override void Undo(WorkspaceViewModel workspaceVM)
     {
-        if (NodeBeforeHistoryAction is not null)
+        if (!workspaceVM.Nodes.Contains(Node))
         {
-            workspaceVM.Nodes.Add(NodeBeforeHistoryAction);
-            Node = NodeBeforeHistoryAction;
-            NodeBeforeHistoryAction = null;
+            workspaceVM.Nodes.Add(Node);
         }
     }
 
     public override void Redo(WorkspaceViewModel workspaceVM)
     {
-        if (Node is not null)
-        {
-            NodeBeforeHistoryAction = Node.Clone();
-            workspaceVM.Nodes.Remove(Node);
-        }
+        workspaceVM.Nodes.Remove(Node);
     }
 }

--- a/Models/Actions/NodeActionModelBase.cs
+++ b/Models/Actions/NodeActionModelBase.cs
@@ -7,8 +7,6 @@ namespace dboard.Models;
 public abstract partial class NodeActionModelBase : ObservableObject
 {
     [ObservableProperty]
-    private NodeViewModelBase? _nodeBeforeHistoryAction;
-    [ObservableProperty]
     private NodeViewModelBase? _node;
 
     public NodeActionModelBase(NodeViewModelBase node)

--- a/Models/Actions/NodeActionModelBase.cs
+++ b/Models/Actions/NodeActionModelBase.cs
@@ -7,7 +7,7 @@ namespace dboard.Models;
 public abstract partial class NodeActionModelBase : ObservableObject
 {
     [ObservableProperty]
-    private NodeViewModelBase? _node;
+    private NodeViewModelBase _node;
 
     public NodeActionModelBase(NodeViewModelBase node)
     {

--- a/ViewModels/WorkspaceViewModel.cs
+++ b/ViewModels/WorkspaceViewModel.cs
@@ -204,6 +204,15 @@ public partial class WorkspaceViewModel : ObservableObject
         WeakReferenceMessenger.Default.Send(new CreateNodeActionModel(nodeVM));
     }
 
+    private void _RemoveNodes(ObservableCollection<NodeViewModelBase> nodes)
+    {
+        foreach (var nodeVM in nodes)
+        {
+            WeakReferenceMessenger.Default.Send(new LogActionMessage(new DeleteNodeActionModel(nodeVM)));
+        }
+        Nodes.RemoveMany(SelectedNodes);
+    }
+
     private void _DeleteNodes()
     {
         // Deregisters move messenger through the property listener in InteractiveView
@@ -213,7 +222,7 @@ public partial class WorkspaceViewModel : ObservableObject
         }
 
         // Remove nodes
-        Nodes.RemoveMany(SelectedNodes);
+        _RemoveNodes(SelectedNodes);
 
         // Remove edges
         var edgesToRemove = new Collection<EdgeViewModel>();


### PR DESCRIPTION
﻿ ### Summary
Implemented undo and redo for deleting a node. Also updated existing undo redo logic to just keep the reference node instead of deleting and cloning it, allowing other actions to maintain the reference

 ### Changes
- Added action model for deleting a node
- Log deleting nodes
- Updated undo redo logic to keep reference node after undo / redo actions