### PR TITLE
MA-146: Fix scrolling not working when doing it on top of a node

### DIFF
--- a/Views/InteractiveView.axaml
+++ b/Views/InteractiveView.axaml
@@ -35,68 +35,65 @@
 			PointerPressed="SelectNodeEdge"
 			PointerReleased="ReleaseNodeEdge"/>
 	
-	<AdornerLayer Grid.Row="1">
-		<AdornerLayer.Adorner>
-			<Grid
-				Name="AdornerGrid"
-				ColumnDefinitions="Auto,*,Auto"
-				RowDefinitions="Auto,*,Auto">
-				<Grid.ContextMenu>
-					<ContextMenu>
-						<MenuItem Header="Set Image" Command="{Binding OpenImageDialogCommand}"/>
-						<MenuItem Header="Remove Image" Command="{Binding RemoveImageCommand}"/>
-						<MenuItem Header="Copy" Command="{Binding CopyNodeCommand}"/>
-						<MenuItem Header="Delete" Command="{Binding DeleteNodeCommand}"/>
-					</ContextMenu>
-				</Grid.ContextMenu>
-			
-				<Panel Tag="xy" Background="Transparent" Cursor="TopLeftCorner"
-					   Grid.Row="0" Grid.Column="0" Width="8" Height="8"
-					   PointerPressed="ResizePointerPressed"
-					   PointerReleased="ResizePointerReleased"
-					   PointerMoved="ResizePointerMoved" />
-				<Panel Tag="Xy" Background="Transparent" Cursor="TopRightCorner"
-					   Grid.Row="0" Grid.Column="2" Width="8" Height="8"
-					   PointerPressed="ResizePointerPressed"
-					   PointerReleased="ResizePointerReleased"
-					   PointerMoved="ResizePointerMoved" />
-				<Panel Tag="xY" Background="Transparent" Cursor="BottomLeftCorner"
-					   Grid.Row="2" Grid.Column="0" Width="8" Height="8"
-					   PointerPressed="ResizePointerPressed"
-					   PointerReleased="ResizePointerReleased"
-					   PointerMoved="ResizePointerMoved" />
-				<Panel Tag="XY" Background="Transparent" Cursor="BottomRightCorner"
-					   Grid.Row="2" Grid.Column="2" Width="8" Height="8"
-					   PointerPressed="ResizePointerPressed"
-					   PointerReleased="ResizePointerReleased"
-					   PointerMoved="ResizePointerMoved" />
-				<Panel Tag="y" Background="Transparent" Cursor="TopSide"
-					   Grid.Row="0" Grid.Column="1"
-					   PointerPressed="ResizePointerPressed"
-					   PointerReleased="ResizePointerReleased"
-					   PointerMoved="ResizePointerMoved" />
-				<Panel Tag="x" Background="Transparent" Cursor="LeftSide"
-					   Grid.Row="1" Grid.Column="0"
-					   PointerPressed="ResizePointerPressed"
-					   PointerReleased="ResizePointerReleased"
-					   PointerMoved="ResizePointerMoved" />
-				<Panel Tag="X" Background="Transparent" Cursor="RightSide"
-					   Grid.Row="1" Grid.Column="2"
-					   PointerPressed="ResizePointerPressed"
-					   PointerReleased="ResizePointerReleased"
-					   PointerMoved="ResizePointerMoved" />
-				<Panel Tag="Y" Background="Transparent" Cursor="BottomSide"
-					   Grid.Row="2" Grid.Column="1"
-					   PointerPressed="ResizePointerPressed"
-					   PointerReleased="ResizePointerReleased"
-					   PointerMoved="ResizePointerMoved" />
-				<Panel Background="Transparent"
-					   Grid.Row="1" Grid.Column="1" Opacity="0.3"
-					   IsHitTestVisible="{Binding !IsEdit}"
-					   PointerPressed="MovePointerPressed"
-					   PointerReleased="MovePointerReleased"
-					   PointerMoved="MovePointerMoved"/>
-			</Grid>
-		</AdornerLayer.Adorner>
-	</AdornerLayer>
+
+	<Grid Grid.Row="1"
+			ZIndex="10000"
+			Name="InteractiveGrid"
+			ColumnDefinitions="Auto,*,Auto"
+			RowDefinitions="Auto,*,Auto">
+		<Grid.ContextMenu>
+			<ContextMenu>
+				<MenuItem Header="Set Image" Command="{Binding OpenImageDialogCommand}"/>
+				<MenuItem Header="Remove Image" Command="{Binding RemoveImageCommand}"/>
+				<MenuItem Header="Copy" Command="{Binding CopyNodeCommand}"/>
+				<MenuItem Header="Delete" Command="{Binding DeleteNodeCommand}"/>
+			</ContextMenu>
+		</Grid.ContextMenu>
+		<Panel Tag="xy" Background="Transparent" Cursor="TopLeftCorner"
+				Grid.Row="0" Grid.Column="0" Width="8" Height="8"
+				PointerPressed="ResizePointerPressed"
+				PointerReleased="ResizePointerReleased"
+				PointerMoved="ResizePointerMoved" />
+		<Panel Tag="Xy" Background="Transparent" Cursor="TopRightCorner"
+				Grid.Row="0" Grid.Column="2" Width="8" Height="8"
+				PointerPressed="ResizePointerPressed"
+				PointerReleased="ResizePointerReleased"
+				PointerMoved="ResizePointerMoved" />
+		<Panel Tag="xY" Background="Transparent" Cursor="BottomLeftCorner"
+				Grid.Row="2" Grid.Column="0" Width="8" Height="8"
+				PointerPressed="ResizePointerPressed"
+				PointerReleased="ResizePointerReleased"
+				PointerMoved="ResizePointerMoved" />
+		<Panel Tag="XY" Background="Transparent" Cursor="BottomRightCorner"
+				Grid.Row="2" Grid.Column="2" Width="8" Height="8"
+				PointerPressed="ResizePointerPressed"
+				PointerReleased="ResizePointerReleased"
+				PointerMoved="ResizePointerMoved" />
+		<Panel Tag="y" Background="Transparent" Cursor="TopSide"
+				Grid.Row="0" Grid.Column="1"
+				PointerPressed="ResizePointerPressed"
+				PointerReleased="ResizePointerReleased"
+				PointerMoved="ResizePointerMoved" />
+		<Panel Tag="x" Background="Transparent" Cursor="LeftSide"
+				Grid.Row="1" Grid.Column="0"
+				PointerPressed="ResizePointerPressed"
+				PointerReleased="ResizePointerReleased"
+				PointerMoved="ResizePointerMoved" />
+		<Panel Tag="X" Background="Transparent" Cursor="RightSide"
+				Grid.Row="1" Grid.Column="2"
+				PointerPressed="ResizePointerPressed"
+				PointerReleased="ResizePointerReleased"
+				PointerMoved="ResizePointerMoved" />
+		<Panel Tag="Y" Background="Transparent" Cursor="BottomSide"
+				Grid.Row="2" Grid.Column="1"
+				PointerPressed="ResizePointerPressed"
+				PointerReleased="ResizePointerReleased"
+				PointerMoved="ResizePointerMoved" />
+		<Panel Background="Transparent"
+				Grid.Row="1" Grid.Column="1"
+				IsHitTestVisible="{Binding !IsEdit}"
+				PointerPressed="MovePointerPressed"
+				PointerReleased="MovePointerReleased"
+				PointerMoved="MovePointerMoved" />
+	</Grid>
 </Grid>

--- a/Views/InteractiveView.axaml.cs
+++ b/Views/InteractiveView.axaml.cs
@@ -1,5 +1,4 @@
 using Avalonia.Input;
-using Avalonia.Media;
 using Avalonia;
 using dboard.ViewModels;
 using CommunityToolkit.Mvvm.Messaging;
@@ -11,7 +10,6 @@ using Avalonia.VisualTree;
 using Avalonia.LogicalTree;
 using dboard.Models;
 using System.Threading.Tasks;
-using dboard.Models.Actions.Node;
 
 namespace dboard.Views;
 
@@ -43,11 +41,13 @@ public partial class InteractiveView : Grid
             // Set drag drop image
             if (_vm is NodeViewModel nodeVM)
             {
-                Grid adorner = this.FindControl<Grid>("AdornerGrid");
-                DragDrop.SetAllowDrop(this, true);
-                DragDrop.SetAllowDrop(adorner, true);
-                adorner.AddHandler(DragDrop.DropEvent, DropImage);
-                AddHandler(DragDrop.DropEvent, DropImage);
+                if (this.FindControl<Grid>("InteractiveGrid") is Grid interactiveGrid)
+                {
+                    DragDrop.SetAllowDrop(this, true);
+                    DragDrop.SetAllowDrop(interactiveGrid, true);
+                    interactiveGrid.AddHandler(DragDrop.DropEvent, DropImage);
+                    AddHandler(DragDrop.DropEvent, DropImage);
+                }
 
             }
         }
@@ -196,7 +196,6 @@ public partial class InteractiveView : Grid
             }
         }
     }
-
     private bool _IsImage(string url)
     {
         return ImageConstants.IMAGE_URL_REGEX.IsMatch(url);

--- a/Views/MainContentView.axaml
+++ b/Views/MainContentView.axaml
@@ -227,7 +227,11 @@
 	</SplitView>
 
 	<!-- Workspace -->
-	<Border Grid.Row="1" Grid.Column="2" ClipToBounds="True" CornerRadius="8" PointerWheelChanged="HandleZoom" PointerPressed="WorkspaceOnPointerPressed" PointerMoved="WorkspaceOnPointerMoved" PointerReleased="WorkspaceOnPointerReleased">
+	<Border Grid.Row="1" Grid.Column="2" ClipToBounds="True" CornerRadius="8" 
+			PointerWheelChanged="HandleZoom" 
+			PointerPressed="WorkspaceOnPointerPressed" 
+			PointerMoved="WorkspaceOnPointerMoved" 
+			PointerReleased="WorkspaceOnPointerReleased">
 		<Border.Background>
 			<MultiBinding Converter="{StaticResource ARGBBrushConverter}">
 				<Binding Path="SharedSettings.ModeModel.BackgroundA"/>


### PR DESCRIPTION
﻿ ### Summary
When trying to scroll on top of a node (to zoom in / out), it won't work. This also only happens when not editing the node, where editing the node scrolling works. Fix was removing the adorner from interactive view. The adorner would eat up inputs, and since it is on top of all controls, the input would not reach the main content view. Removing the adorner fixed it, and works as expected (not really sure why adorner was needed in the first place)
 ### Changes
- Remove adorner from interactive view so it doesn't eat up input